### PR TITLE
Null-safe update of unit in signalling_callback

### DIFF
--- a/custom_components/casambi/light.py
+++ b/custom_components/casambi/light.py
@@ -309,7 +309,9 @@ class CasambiController:
 
         if signal == SIGNAL_DATA:
             for key, value in data.items():
-                self.units[key].process_update(value)
+                unit = self.units.get(key)
+                if unit:
+                    self.units[key].process_update(value)
         elif signal == SIGNAL_CONNECTION_STATE and (data == STATE_STOPPED):
             _LOGGER.debug("signalling_callback websocket STATE_STOPPED")
 


### PR DESCRIPTION
If signalling_callback receives an update for a unit that's not in self.units yet, it currently crashes. This PR makes that operation null-safe.

It'd probably be better to discover new lights as they are turned on, but at least with this it doesn't crash.