### PR TITLE
feat(repairs): add repair for restarting after setup

### DIFF
--- a/custom_components/casambi/light.py
+++ b/custom_components/casambi/light.py
@@ -50,6 +50,7 @@ from homeassistant import config_entries, core
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.const import ATTR_NAME
 from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.issue_registry import async_create_issue, IssueSeverity
 from homeassistant.const import CONF_EMAIL, CONF_API_KEY, CONF_SCAN_INTERVAL
 
 import voluptuous as vol
@@ -111,6 +112,19 @@ async def async_setup_entry(
     if CONF_CONTROLLER in hass.data[DOMAIN]:
         dbg_msg = "async_setup_platform CasambiController already created!"
         _LOGGER.debug(dbg_msg)
+
+        async_create_issue(
+            hass=hass,
+            domain=DOMAIN,
+            issue_id=f"restart_required_casambi",x
+            is_fixable=True,
+            issue_domain=DOMAIN,
+            severity=IssueSeverity.WARNING,
+            translation_key="restart_required",
+            translation_placeholders={
+                "name": "Casambi",
+            },
+        )
         return
 
     hass.data[DOMAIN][CONF_CONTROLLER] = CasambiController(hass)

--- a/custom_components/casambi/light.py
+++ b/custom_components/casambi/light.py
@@ -116,7 +116,7 @@ async def async_setup_entry(
         async_create_issue(
             hass=hass,
             domain=DOMAIN,
-            issue_id=f"restart_required_casambi",x
+            issue_id=f"restart_required_casambi",
             is_fixable=True,
             issue_domain=DOMAIN,
             severity=IssueSeverity.WARNING,

--- a/custom_components/casambi/light.py
+++ b/custom_components/casambi/light.py
@@ -121,9 +121,7 @@ async def async_setup_entry(
             issue_domain=DOMAIN,
             severity=IssueSeverity.WARNING,
             translation_key="restart_required",
-            translation_placeholders={
-                "name": "Casambi",
-            },
+            translation_placeholders={},
         )
         return
 

--- a/custom_components/casambi/repairs.py
+++ b/custom_components/casambi/repairs.py
@@ -1,0 +1,51 @@
+"""Repairs platform for Casambi."""
+
+from __future__ import annotations
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+class RestartRequiredFixFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    def __init__(self, issue_id: str) -> None:
+        self.issue_id = issue_id
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return await (self.async_step_confirm_restart())
+
+    async def async_step_confirm_restart(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            await self.hass.services.async_call("homeassistant", "restart")
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="confirm_restart",
+            data_schema=vol.Schema({}),
+            description_placeholders={"name": "Casambi"},
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None = None,
+    *args: Any,
+    **kwargs: Any,
+) -> RepairsFlow | None:
+    """Create flow."""
+    if issue_id.startswith("restart_required"):
+        return RestartRequiredFixFlow(issue_id)
+    return None

--- a/custom_components/casambi/repairs.py
+++ b/custom_components/casambi/repairs.py
@@ -34,7 +34,7 @@ class RestartRequiredFixFlow(RepairsFlow):
         return self.async_show_form(
             step_id="confirm_restart",
             data_schema=vol.Schema({}),
-            description_placeholders={"name": "Casambi"},
+            description_placeholders={},
         )
 
 

--- a/custom_components/casambi/translations/de.json
+++ b/custom_components/casambi/translations/de.json
@@ -29,5 +29,18 @@
       "auth_user_password":"Ung\u00fcltiges Benutzer Passwort",
       "auth_network_password":"Ung\u00fcltiges Netzwerk Passwort"
     }
+  },
+  "issues": {
+    "restart_required": {
+      "title": "Neustart notwendig",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Neustart notwendig",
+            "description": "Um deine Lampen zu erkennen ist ein Neustart von Home Assistant notwendig, klicke auf absenden um jetzt neuzustarten."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/casambi/translations/de.json
+++ b/custom_components/casambi/translations/de.json
@@ -37,7 +37,7 @@
         "step": {
           "confirm_restart": {
             "title": "Neustart notwendig",
-            "description": "Um deine Lampen zu erkennen ist ein Neustart von Home Assistant notwendig, klicke auf absenden um jetzt neuzustarten."
+            "description": "Home Assistant muss neugestartet werden um deine Lampen zu erkennen, klicke auf absenden um jetzt neuzustarten."
           }
         }
       }

--- a/custom_components/casambi/translations/en.json
+++ b/custom_components/casambi/translations/en.json
@@ -29,5 +29,18 @@
       "auth_user_password":"Invalid user password",
       "auth_network_password":"Invalid network password"
     }
+  },
+  "issues": {
+    "restart_required": {
+      "title": "Restart required",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Restart required",
+            "description": "Restart of Home Assistant is required to detect your lights, click submit to restart now."
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
When the integration is removed and setup again, the lights do not show up and the log states the message `CasambiController already created!`. When Home Assistant is restarted, the light are discovered.

This PR adds a *Repair* to notify the user to restart in this case. His is copied over from [HACS](https://github.com/hacs/integration/blob/main/custom_components/hacs/repairs.py).