### PR TITLE
refactor: move CasambiLight class to own file

### DIFF
--- a/custom_components/casambi/casambi/CasambiEntity.py
+++ b/custom_components/casambi/casambi/CasambiEntity.py
@@ -1,0 +1,72 @@
+"""
+Support for Casambi lights.
+"""
+import logging
+
+from typing import Any, Dict
+
+from homeassistant.const import ATTR_NAME
+from homeassistant.helpers.entity import Entity
+
+from ..const import (
+    DOMAIN,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CasambiEntity(Entity):
+    """Defines a Casambi Entity."""
+
+    def __init__(self, unit, controller, hass):
+        """Initialize Casambi Entity."""
+        self.unit = unit
+        self.controller = controller
+        self.hass = hass
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return self.unit.name
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this sensor."""
+        return self.unit.unique_id
+
+    @property
+    def model(self):
+        """Return the model for this sensor."""
+        if self.unit.fixture_model:
+            return self.unit.fixture_model
+        return "Casambi"
+
+    @property
+    def brand(self):
+        """Return the brand for this sensor."""
+        if self.unit.oem:
+            return self.unit.oem
+        return "Casambi"
+
+    @property
+    def device_info(self) -> Dict[str, Any]:
+        """Return device information about this Casambi Key Light."""
+        return {
+            ATTR_IDENTIFIERS: {(DOMAIN, self.unique_id)},
+            ATTR_NAME: self.unit.name,
+            ATTR_MANUFACTURER: self.brand,
+            ATTR_MODEL: self.model,
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.unit.online
+
+    @property
+    def should_poll(self):
+        """Disable polling by returning False"""
+        return False

--- a/custom_components/casambi/light.py
+++ b/custom_components/casambi/light.py
@@ -9,7 +9,7 @@ import asyncio
 
 from datetime import timedelta
 from pprint import pformat
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import async_timeout
 import aiocasambi
@@ -25,15 +25,6 @@ from aiocasambi.consts import (
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    SUPPORT_BRIGHTNESS,
-    LightEntity,
-    ATTR_COLOR_TEMP,
-    ATTR_RGB_COLOR,
-    ATTR_RGBW_COLOR,
-    COLOR_MODE_BRIGHTNESS,
-    COLOR_MODE_COLOR_TEMP,
-    COLOR_MODE_RGB,
-    COLOR_MODE_RGBW,
 )
 
 try:
@@ -41,16 +32,12 @@ try:
 except ImportError:
     ATTR_DISTRIBUTION = "distribution"
 
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from homeassistant import config_entries, core
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.const import ATTR_NAME, CONF_EMAIL, CONF_API_KEY, CONF_SCAN_INTERVAL
 from homeassistant.helpers import aiohttp_client
+from homeassistant.const import CONF_EMAIL, CONF_API_KEY, CONF_SCAN_INTERVAL
 
 import voluptuous as vol
 from homeassistant.helpers import entity_platform
@@ -61,9 +48,6 @@ from .const import (
     CONF_USER_PASSWORD,
     CONF_NETWORK_PASSWORD,
     CONF_NETWORK_TIMEOUT,
-    ATTR_IDENTIFIERS,
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
     DEFAULT_NETWORK_TIMEOUT,
     DEFAULT_POLLING_TIME,
     SERVICE_CASAMBI_LIGHT_TURN_ON,
@@ -82,8 +66,8 @@ CASAMBI_CONTROLLER = None
 
 
 async def async_setup_entry(
-    hass: core.HomeAssistant,
-    config_entry: config_entries.ConfigEntry,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
     async_add_entities,
 ):
     """Setup sensors from a config entry created in the integrations UI."""

--- a/custom_components/casambi/light.py
+++ b/custom_components/casambi/light.py
@@ -41,6 +41,7 @@ try:
 except ImportError:
     ATTR_DISTRIBUTION = "distribution"
 
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -48,9 +49,8 @@ from homeassistant.helpers.update_coordinator import (
 
 from homeassistant import config_entries, core
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.const import ATTR_NAME
+from homeassistant.const import ATTR_NAME, CONF_EMAIL, CONF_API_KEY, CONF_SCAN_INTERVAL
 from homeassistant.helpers import aiohttp_client
-from homeassistant.const import CONF_EMAIL, CONF_API_KEY, CONF_SCAN_INTERVAL
 
 import voluptuous as vol
 from homeassistant.helpers import entity_platform
@@ -74,6 +74,7 @@ from .const import (
 )
 
 from .errors import ConfigurationError
+from .casambi.CasambiLightEntity import CasambiLightEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -190,7 +191,7 @@ async def async_setup_entry(
         if not unit.is_light():
             continue
 
-        casambi_light = CasambiLight(
+        casambi_light = CasambiLightEntity(
             coordinator, unit.unique_id, unit, controller, hass
         )
         async_add_entities([casambi_light], True)
@@ -328,7 +329,7 @@ async def async_setup_platform(
         if not unit.is_light():
             continue
 
-        casambi_light = CasambiLight(
+        casambi_light = CasambiLightEntity(
             coordinator, unit.unique_id, unit, controller, hass
         )
         async_add_entities([casambi_light], True)
@@ -503,327 +504,3 @@ class CasambiController:
             for unit in data:
                 self.update_unit_state(unit)
 
-
-class CasambiLight(CoordinatorEntity, LightEntity):
-    """Defines a Casambi Key Light."""
-
-    def __init__(self, coordinator, idx, unit, controller, hass):
-        """Initialize Casambi Key Light."""
-        super().__init__(coordinator)
-        self.idx = idx
-        self._brightness: Optional[int] = None
-        self._distribution: Optional[int] = None
-        self._state: Optional[bool] = None
-        self._temperature: Optional[int] = None
-        self.unit = unit
-        self.controller = controller
-        self.hass = hass
-
-    @property
-    def name(self) -> str:
-        """Return the name of the entity."""
-        return self.unit.name
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.unit.online
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID for this sensor."""
-        return self.unit.unique_id
-
-    @property
-    def brightness(self) -> Optional[int]:
-        """Return the brightness of this light between 1..255."""
-        return self._brightness
-
-    @property
-    def distribution(self) -> Optional[int]:
-        """Return the distribution of this light between 1..255."""
-        return self._distribution
-
-    @property
-    def min_mireds(self) -> int:
-        """
-        Return the coldest color_temp that this light supports.
-
-        M = 1000000 / T
-
-        25000 K, has a mired value of M = 40 mireds
-        1000000 / 25000 = 40
-        """
-        return self.unit.get_min_mired()
-
-    @property
-    def max_mireds(self) -> int:
-        """
-        Return the warmest color_temp that this light supports.
-
-        M = 1000000 / T
-
-        25000 K, has a mired value of M = 40 mireds
-        1000000 / 25000 = 40
-
-        {
-            'Dimmer': {
-                'type': 'Dimmer',
-                'value': 0.0
-                },
-            'CCT': {
-                'min': 2200,
-                'max': 6000,
-                'level': 0.4631578947368421,
-                'type': 'CCT',
-                'value': 3960.0
-                }
-        }
-        """
-        return self.unit.get_max_mired()
-
-    @property
-    def color_temp(self) -> int:
-        """Return the CT color value in mireds."""
-        return self.unit.get_color_temp()
-
-    @property
-    def rgb_color(self):
-        return self.unit.get_rgb_color()
-
-    @property
-    def rgbw_color(self):
-        return self.unit.get_rgbw_color()
-
-    @property
-    def supported_features(self) -> int:
-        """
-        Flag supported features.
-
-        This is deprecated and will be removed in Home Assistant 2021.10.
-        """
-        return SUPPORT_BRIGHTNESS
-
-    @property
-    def color_mode(self):
-        """Set color mode for this entity."""
-        if self.unit.supports_rgbw():
-            return COLOR_MODE_RGBW
-        if self.unit.supports_rgb():
-            return COLOR_MODE_RGB
-        if self.unit.supports_color_temperature():
-            return COLOR_MODE_COLOR_TEMP
-        if self.unit.supports_brightness():
-            return COLOR_MODE_BRIGHTNESS
-
-        return None
-
-    @property
-    def supported_color_modes(self):
-        """Flag supported color_modes (in an array format)."""
-        supports = []
-
-        if self.unit.supports_brightness():
-            supports.append(COLOR_MODE_BRIGHTNESS)
-
-        if self.unit.supports_color_temperature():
-            supports.append(COLOR_MODE_COLOR_TEMP)
-
-        if self.unit.supports_rgbw():
-            supports.append(COLOR_MODE_RGBW)
-        elif self.unit.supports_rgb():
-            supports.append(COLOR_MODE_RGB)
-
-        return supports
-
-    @property
-    def is_on(self) -> bool:
-        """Return the state of the light."""
-        return bool(self._state)
-
-    @property
-    def extra_state_attributes(self):  # -> dict[str, str] | None:
-        #    """Return the optional state attributes."""
-        return {
-            "distribution": self._distribution,
-        }
-
-    def set_online(self, online):
-        """
-        Set unit to online
-        """
-        self.unit.online = online
-
-        dbg_msg = "set_online: Setting online to "
-        dbg_msg += f'"{online}" for unit {self}'
-        _LOGGER.debug(dbg_msg)
-
-        if self.enabled:
-            # Device needs to be enabled for us to schedule updates
-            self.async_schedule_update_ha_state(True)
-
-    def update_state(self):
-        """
-        Update units state
-        """
-        if self.enabled:
-            # Device needs to be enabled for us to schedule updates
-            _LOGGER.debug(f"update_state {self}")
-            self.async_schedule_update_ha_state(True)
-
-    def process_update(self, data):
-        """Process callback message, update home assistant light state"""
-        _LOGGER.debug(f"process_update: self: {self} data: {data}")
-
-        if self.enabled:
-            # Device needs to be enabled for us to schedule updates
-            self.async_schedule_update_ha_state(True)
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """
-        Turn light off
-        """
-        _LOGGER.debug(f"async_turn_off {self}")
-
-        await self.unit.turn_unit_off()
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn on the light."""
-        _LOGGER.debug(f"async_turn_on {self} unit: {self.unit} kwargs: {kwargs}")
-        brightness = 255
-        distribution = 255
-
-        if ATTR_COLOR_TEMP in kwargs:
-            dbg_msg = "async_turn_on: ATTR_COLOR_TEMP:"
-            dbg_msg += f" {kwargs[ATTR_COLOR_TEMP]}"
-            _LOGGER.debug(dbg_msg)
-
-            color_temp = kwargs[ATTR_COLOR_TEMP]
-
-            dbg_msg = "async_turn_on:"
-            dbg_msg += f"setting unit color name={self.name}"
-            dbg_msg += f" color_temp={color_temp}"
-            _LOGGER.debug(dbg_msg)
-
-            await self.unit.set_unit_color_temperature(value=color_temp, source="mired")
-
-            return
-
-        if ATTR_RGBW_COLOR in kwargs:
-            (red, green, blue, white) = kwargs[ATTR_RGBW_COLOR]
-
-            dbg_msg = "async_turn_on:"
-            dbg_msg += f"setting unit color name={self.name}"
-            dbg_msg += f" rgbw=({red}, {green}, {blue}, {white})"
-            _LOGGER.debug(dbg_msg)
-
-            await self.unit.set_unit_rgbw(
-                color_value=(red, green, blue, white),
-            )
-
-            return
-
-        if ATTR_RGB_COLOR in kwargs:
-            (red, green, blue) = kwargs[ATTR_RGB_COLOR]
-
-            dbg_msg = "async_turn_on:"
-            dbg_msg += f"setting unit color name={self.name}"
-            dbg_msg += f" rgb=({red}, {green}, {blue})"
-            _LOGGER.debug(dbg_msg)
-
-            await self.unit.set_unit_rgb(
-                color_value=(red, green, blue), send_rgb_format=True
-            )
-
-            return
-
-        if ATTR_BRIGHTNESS in kwargs:
-            brightness = round((kwargs[ATTR_BRIGHTNESS] / 255.0), 2)
-
-        if brightness == 255:
-            dbg_msg = "async_turn_on:"
-            dbg_msg += f"turning unit on name={self.name}"
-            _LOGGER.debug(dbg_msg)
-
-            await self.unit.turn_unit_on()
-        else:
-            dbg_msg = "async_turn_on:"
-            dbg_msg += f"setting units brightness name={self.name}"
-            dbg_msg += f" brightness={brightness}"
-            _LOGGER.debug(dbg_msg)
-
-            await self.unit.set_unit_value(value=brightness)
-
-        if ATTR_DISTRIBUTION in kwargs:
-            distribution = round((kwargs[ATTR_DISTRIBUTION] / 255.0), 2)
-
-            dbg_msg = "async_turn_on:"
-            dbg_msg += f"setting units distribution name={self.name}"
-            dbg_msg += f" distribution={distribution}"
-            _LOGGER.debug(dbg_msg)
-
-            await self.unit.set_unit_distribution(distribution=distribution)
-
-    @property
-    def should_poll(self):
-        """Disable polling by returning False"""
-        return False
-
-    async def async_update(self) -> None:
-        """Update Casambi entity."""
-        if not self.unit.online:
-            _LOGGER.info(f"async_update: unit is not online: {self}")
-        else:
-            if self.unit.value > 0:
-                self._state = True
-                self._brightness = int(round(self.unit.value * 255))
-                self._distribution = int(round(self.unit.distribution * 255))
-            else:
-                self._state = False
-        _LOGGER.debug(f"async_update {self}")
-
-    @property
-    def device_info(self) -> Dict[str, Any]:
-        """Return device information about this Casambi Key Light."""
-        model = "Casambi"
-        manufacturer = "Casambi"
-
-        if self.unit.fixture_model:
-            model = self.unit.fixture_model
-
-        if self.unit.oem:
-            manufacturer = self.unit.oem
-
-        return {
-            ATTR_IDENTIFIERS: {(DOMAIN, self.unique_id)},
-            ATTR_NAME: self.unit.name,
-            ATTR_MANUFACTURER: manufacturer,
-            ATTR_MODEL: model,
-        }
-
-    async def async_handle_entity_service_light_turn_on(self, **kwargs: Any) -> None:
-        """Handle turn on of Casambi light when setup from UI integration."""
-        # Get parameters
-        _brightness = kwargs.get(ATTR_SERV_BRIGHTNESS)
-        _distribution = kwargs.get(ATTR_SERV_DISTRIBUTION, None)
-
-        dbg_msg = f"async_handle_entity_service_light_turn_on: self: {self}, kwargs: {kwargs}, brightness: {_brightness}, distribution: {_distribution}"
-        _LOGGER.debug(dbg_msg)
-
-        params = {}
-        params["brightness"] = _brightness
-        if _distribution is not None:
-            params["distribution"] = _distribution
-
-        dbg_msg = f"async_handle_entity_service_light_turn_on: entity: {self.entity_id}, setting params: {params}"
-        _LOGGER.debug(dbg_msg)
-
-        await self.async_turn_on(**params)
-
-    def __repr__(self) -> str:
-        """Return the representation."""
-        name = self.unit.name
-
-        result = f"<Casambi light {name}: unit={self.unit}"
-
-        return result


### PR DESCRIPTION
This PR moves `CasambiLight` class to an own file and extracts a `CasambiEntity` class from it for future reuse in other entities (see https://github.com/hellqvio86/home_assistant_casambi/issues/54#issuecomment-1321535411)