### PR TITLE
feat: add binary sensor for connectivity status

### DIFF
--- a/custom_components/casambi/__init__.py
+++ b/custom_components/casambi/__init__.py
@@ -25,6 +25,9 @@ async def async_setup_entry(
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "light")
     )
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "binary_sensor")
+    )
     return True
 
 
@@ -42,6 +45,7 @@ async def async_unload_entry(
     unload_ok = all(
         await asyncio.gather(
             *[hass.config_entries.async_forward_entry_unload(entry, "light")]
+            *[hass.config_entries.async_forward_entry_unload(entry, "binary_sensor")]
         )
     )
     # Remove options_update_listener.

--- a/custom_components/casambi/binary_sensor.py
+++ b/custom_components/casambi/binary_sensor.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     # TODO: extract casambi controller from light entity
     casambi_controller = hass.data[DOMAIN][CONF_CONTROLLER]
 
-    units = casambi_controller.controller.get_units()
+    units = casambi_controller.aiocasambi_controller.get_units()
     binary_sensors = []
 
     for unit in units:

--- a/custom_components/casambi/binary_sensor.py
+++ b/custom_components/casambi/binary_sensor.py
@@ -3,7 +3,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .casambi.CasambiOverheatBinarySensorEntity import CasambiOverheatBinarySensorEntity
+# from .casambi.CasambiOverheatBinarySensorEntity import CasambiOverheatBinarySensorEntity
 from .casambi.CasambiStatusBinarySensorEntity import CasambiStatusBinarySensorEntity
 from .const import (
     DOMAIN,
@@ -18,19 +18,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
     _LOGGER.debug("Setting up binary sensor entities.")
 
-    casambi_controller = hass.data[DOMAIN][CONF_CONTROLLER]
-    units = casambi_controller.aiocasambi_controller.get_units()
+    controller = hass.data[DOMAIN][CONF_CONTROLLER]
+    units = controller.aiocasambi_controller.get_units()
     binary_sensors = []
 
     for unit in units:
         _LOGGER.debug("Adding CasambiStatusBinarySensorEntity...")
-        binary_sensors.append(CasambiStatusBinarySensorEntity(unit, casambi_controller, hass))
+        binary_sensors.append(CasambiStatusBinarySensorEntity(unit, controller, hass))
         
         # TODO: check for overheat control
         # 'controls': [[{'name': 'overheat', 'type': 'Overheat', 'status': 'ok'}, {'name': 'dimmer0', 'type': 'Dimmer', 'value': 0.0}]]
         # if ...
           #  _LOGGER.debug("Adding CasambiOverheatBinarySensorEntity...")
-          #  binary_sensors.append(CasambiOverheatBinarySensorEntity(unit, casambi_controller, hass))
+          #  binary_sensors.append(CasambiOverheatBinarySensorEntity(unit, controller, hass))
 
     if binary_sensors:
         _LOGGER.debug("Adding binary sensor entities...")

--- a/custom_components/casambi/binary_sensor.py
+++ b/custom_components/casambi/binary_sensor.py
@@ -21,25 +21,23 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
 
     # TODO: extract casambi controller from light entity
     casambi_controller = hass.data[DOMAIN][CONF_CONTROLLER]
-    coordinator = hass.data[DOMAIN]["coordinator"]
-    await coordinator.async_refresh()
 
     units = casambi_controller.controller.get_units()
-    binarySensors = []
+    binary_sensors = []
 
     for unit in units:
         _LOGGER.debug("Adding CasambiStatusBinarySensorEntity...")
-        binarySensors.append(CasambiStatusBinarySensorEntity(unit, casambi_controller.controller, hass))
-
+        binary_sensors.append(CasambiStatusBinarySensorEntity(unit, casambi_controller, hass))
+        
         # TODO: check for overheat control
         # 'controls': [[{'name': 'overheat', 'type': 'Overheat', 'status': 'ok'}, {'name': 'dimmer0', 'type': 'Dimmer', 'value': 0.0}]]
         # if ...
           #  _LOGGER.debug("Adding CasambiOverheatBinarySensorEntity...")
-          #  binarySensors.append(CasambiOverheatBinarySensorEntity(unit, casambi_controller.controller, hass))
+          #  binary_sensors.append(CasambiOverheatBinarySensorEntity(unit, casambi_controller, hass))
 
-    if binarySensors:
+    if binary_sensors:
         _LOGGER.debug("Adding binary sensor entities...")
-        async_add_entities(binarySensors)
+        async_add_entities(binary_sensors)
     else:
         _LOGGER.debug("No binary sensor entities available.")
 

--- a/custom_components/casambi/binary_sensor.py
+++ b/custom_components/casambi/binary_sensor.py
@@ -4,6 +4,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .casambi.CasambiStatusBinarySensorEntity import CasambiStatusBinarySensorEntity
+from .casambi.CasambiOverheatBinarySensorEntity import CasambiOverheatBinarySensorEntity
 from .const import (
     DOMAIN,
     CONF_CONTROLLER,
@@ -28,6 +29,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     for unit in units:
         _LOGGER.debug("Adding CasambiStatusBinarySensorEntity...")
         binarySensors.append(CasambiStatusBinarySensorEntity(unit, controller, hass))
+        
+        # check for overheat control
+        # 'controls': [[{'name': 'overheat', 'type': 'Overheat', 'status': 'ok'}, {'name': 'dimmer0', 'type': 'Dimmer', 'value': 0.0}]]
+        # if ...
+        #    _LOGGER.debug("Adding CasambiOverheatBinarySensorEntity...")
+        #    binarySensors.append(CasambiOverheatBinarySensorEntity(unit, controller, hass))
 
     if binarySensors:
         _LOGGER.debug("Adding binary sensor entities...")

--- a/custom_components/casambi/binary_sensor.py
+++ b/custom_components/casambi/binary_sensor.py
@@ -1,0 +1,36 @@
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .casambi.CasambiStatusBinarySensorEntity import CasambiStatusBinarySensorEntity
+from .const import (
+    DOMAIN,
+    CONF_CONTROLLER,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    return True
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
+    _LOGGER.debug("Setting up binary sensor entities.")
+    # config = hass.data[DOMAIN][config_entry.entry_id]
+
+    # casambi_controller = hass.data[DOMAIN][config_entry.entry_id][CONF_CONTROLLER]
+    # controller = casambi_controller.controller
+    # units = controller.get_units()
+    units = []
+
+    binarySensors = []
+
+    for unit in units:
+        _LOGGER.debug("Adding CasambiStatusBinarySensorEntity...")
+        binarySensors.append(CasambiStatusBinarySensorEntity(unit, controller, hass))
+
+    if binarySensors:
+        _LOGGER.debug("Adding binary sensor entities...")
+        async_add_entities(binarySensors)
+    else:
+        _LOGGER.debug("No binary sensor entities available.")

--- a/custom_components/casambi/binary_sensor.py
+++ b/custom_components/casambi/binary_sensor.py
@@ -3,8 +3,8 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .casambi.CasambiStatusBinarySensorEntity import CasambiStatusBinarySensorEntity
 from .casambi.CasambiOverheatBinarySensorEntity import CasambiOverheatBinarySensorEntity
+from .casambi.CasambiStatusBinarySensorEntity import CasambiStatusBinarySensorEntity
 from .const import (
     DOMAIN,
     CONF_CONTROLLER,
@@ -20,25 +20,27 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     # config = hass.data[DOMAIN][config_entry.entry_id]
 
     # TODO: extract casambi controller from light entity
-    # casambi_controller = hass.data[DOMAIN][config_entry.entry_id][CONF_CONTROLLER]
-    # controller = casambi_controller.controller
-    # units = controller.get_units()
-    units = []
+    casambi_controller = hass.data[DOMAIN][CONF_CONTROLLER]
+    coordinator = hass.data[DOMAIN]["coordinator"]
+    await coordinator.async_refresh()
 
+    units = casambi_controller.controller.get_units()
     binarySensors = []
 
     for unit in units:
         _LOGGER.debug("Adding CasambiStatusBinarySensorEntity...")
-        binarySensors.append(CasambiStatusBinarySensorEntity(unit, controller, hass))
-        
+        binarySensors.append(CasambiStatusBinarySensorEntity(unit, casambi_controller.controller, hass))
+
         # TODO: check for overheat control
         # 'controls': [[{'name': 'overheat', 'type': 'Overheat', 'status': 'ok'}, {'name': 'dimmer0', 'type': 'Dimmer', 'value': 0.0}]]
         # if ...
-        #    _LOGGER.debug("Adding CasambiOverheatBinarySensorEntity...")
-        #    binarySensors.append(CasambiOverheatBinarySensorEntity(unit, controller, hass))
+          #  _LOGGER.debug("Adding CasambiOverheatBinarySensorEntity...")
+          #  binarySensors.append(CasambiOverheatBinarySensorEntity(unit, casambi_controller.controller, hass))
 
     if binarySensors:
         _LOGGER.debug("Adding binary sensor entities...")
         async_add_entities(binarySensors)
     else:
         _LOGGER.debug("No binary sensor entities available.")
+
+    return True

--- a/custom_components/casambi/binary_sensor.py
+++ b/custom_components/casambi/binary_sensor.py
@@ -19,6 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     _LOGGER.debug("Setting up binary sensor entities.")
     # config = hass.data[DOMAIN][config_entry.entry_id]
 
+    # TODO: extract casambi controller from light entity
     # casambi_controller = hass.data[DOMAIN][config_entry.entry_id][CONF_CONTROLLER]
     # controller = casambi_controller.controller
     # units = controller.get_units()
@@ -30,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         _LOGGER.debug("Adding CasambiStatusBinarySensorEntity...")
         binarySensors.append(CasambiStatusBinarySensorEntity(unit, controller, hass))
         
-        # check for overheat control
+        # TODO: check for overheat control
         # 'controls': [[{'name': 'overheat', 'type': 'Overheat', 'status': 'ok'}, {'name': 'dimmer0', 'type': 'Dimmer', 'value': 0.0}]]
         # if ...
         #    _LOGGER.debug("Adding CasambiOverheatBinarySensorEntity...")

--- a/custom_components/casambi/binary_sensor.py
+++ b/custom_components/casambi/binary_sensor.py
@@ -17,11 +17,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
     _LOGGER.debug("Setting up binary sensor entities.")
-    # config = hass.data[DOMAIN][config_entry.entry_id]
 
-    # TODO: extract casambi controller from light entity
     casambi_controller = hass.data[DOMAIN][CONF_CONTROLLER]
-
     units = casambi_controller.aiocasambi_controller.get_units()
     binary_sensors = []
 

--- a/custom_components/casambi/casambi/CasambiBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiBinarySensorEntity.py
@@ -1,0 +1,38 @@
+import logging
+
+from homeassistant.core import HomeAssistant
+
+# from homeassistant.components.button import ButtonEntity
+# from homeassistant.components.select import SelectEntity
+# from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.binary_sensor import BinarySensorEntity
+# from homeassistant.helpers.entity import DeviceInfo, Entity
+# from homeassistant.helpers.entity import EntityCategory
+
+from ..const import DOMAIN
+
+from .CasambiEntity import CasambiEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CasambiBinarySensorEntity(BinarySensorEntity, CasambiEntity):
+    def __init__(self, unit, controller, hass, name_suffix: str = "", icon=None, device_class=None):
+    #     self, name_suffix, entry: dict, hass: HomeAssistant, config_entry, icon=None, device_class=None,
+    # ):
+        _LOGGER.debug(f"Casambi {name_suffix} - init - start")
+        self._attr_is_on = False
+        self._hass = hass
+        self._attr_icon = icon
+        self._attr_device_class = device_class
+        # hass.data[DOMAIN][config_entry.entry_id]["entities"].append(self)
+        # self.updateCasambi(hass.data[DOMAIN][config_entry.entry_id]["camData"])
+
+        CasambiEntity.__init__(self, unit, controller, hass)
+        # entry, name_suffix)
+        BinarySensorEntity.__init__(self)
+        _LOGGER.debug(f"Casambi {name_suffix} - init - end")
+
+    @property
+    def state(self):
+        return self._attr_state

--- a/custom_components/casambi/casambi/CasambiBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiBinarySensorEntity.py
@@ -19,7 +19,3 @@ class CasambiBinarySensorEntity(BinarySensorEntity, CasambiEntity):
         self._attr_icon = icon
 
         _LOGGER.debug(f"Casambi {name} - init - end")
-
-    # @property
-    # def state(self):
-    #     return self._attr_state

--- a/custom_components/casambi/casambi/CasambiBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiBinarySensorEntity.py
@@ -1,36 +1,25 @@
 import logging
 
 from homeassistant.core import HomeAssistant
-
-# from homeassistant.components.button import ButtonEntity
-# from homeassistant.components.select import SelectEntity
-# from homeassistant.components.switch import SwitchEntity
 from homeassistant.components.binary_sensor import BinarySensorEntity
-# from homeassistant.helpers.entity import DeviceInfo, Entity
-# from homeassistant.helpers.entity import EntityCategory
 
 from ..const import DOMAIN
-
 from .CasambiEntity import CasambiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-
 class CasambiBinarySensorEntity(BinarySensorEntity, CasambiEntity):
     def __init__(self, unit, controller, hass, name_suffix: str = "", icon=None, device_class=None):
-    #     self, name_suffix, entry: dict, hass: HomeAssistant, config_entry, icon=None, device_class=None,
-    # ):
         _LOGGER.debug(f"Casambi {name_suffix} - init - start")
+
         self._attr_is_on = False
         self._hass = hass
         self._attr_icon = icon
         self._attr_device_class = device_class
-        # hass.data[DOMAIN][config_entry.entry_id]["entities"].append(self)
-        # self.updateCasambi(hass.data[DOMAIN][config_entry.entry_id]["camData"])
 
         CasambiEntity.__init__(self, unit, controller, hass)
-        # entry, name_suffix)
         BinarySensorEntity.__init__(self)
+
         _LOGGER.debug(f"Casambi {name_suffix} - init - end")
 
     @property

--- a/custom_components/casambi/casambi/CasambiBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiBinarySensorEntity.py
@@ -9,19 +9,17 @@ from .CasambiEntity import CasambiEntity
 _LOGGER = logging.getLogger(__name__)
 
 class CasambiBinarySensorEntity(BinarySensorEntity, CasambiEntity):
-    def __init__(self, unit, controller, hass, name_suffix: str = "", icon=None, device_class=None):
-        _LOGGER.debug(f"Casambi {name_suffix} - init - start")
+    def __init__(self, unit, controller, hass, name: str = None, device_class=None, icon=None):
+        _LOGGER.debug(f"Casambi {name} - init - start")
 
-        self._attr_is_on = False
-        self._hass = hass
-        self._attr_icon = icon
-        self._attr_device_class = device_class
-
-        CasambiEntity.__init__(self, unit, controller, hass)
         BinarySensorEntity.__init__(self)
+        CasambiEntity.__init__(self, unit, controller, hass, name)
+        self._attr_is_on = False
+        self._attr_device_class = device_class
+        self._attr_icon = icon
 
-        _LOGGER.debug(f"Casambi {name_suffix} - init - end")
+        _LOGGER.debug(f"Casambi {name} - init - end")
 
-    @property
-    def state(self):
-        return self._attr_state
+    # @property
+    # def state(self):
+    #     return self._attr_state

--- a/custom_components/casambi/casambi/CasambiController.py
+++ b/custom_components/casambi/casambi/CasambiController.py
@@ -82,13 +82,13 @@ class CasambiController:
             # Try again to reconnect
             self._hass.loop.call_later(self._network_retry_timer, self.async_reconnect)
 
-    def update_light_state(self, light):
+    def update_light_state(self, unit_unique_id):
         """
         Update unit state
         """
-        _LOGGER.debug(f"update_light_state: unit: {light} lights: {self.lights}")
+        _LOGGER.debug(f"update_light_state: unit: {unit_unique_id} lights: {self.entities}")
         for entity in self.entities:
-            if entity._unit_unique_id == light:
+            if entity._unit_unique_id == unit_unique_id:
                 entity.update_state()
 
     def update_all_lights(self):

--- a/custom_components/casambi/casambi/CasambiController.py
+++ b/custom_components/casambi/casambi/CasambiController.py
@@ -23,12 +23,12 @@ _LOGGER = logging.getLogger(__name__)
 class CasambiController:
     """Manages a single Casambi Controller."""
 
-    def __init__(self, hass, network_retry_timer=30, lights={}):
+    def __init__(self, hass, network_retry_timer=30, entities=[]):
         """Initialize the system."""
         self._hass = hass
         self._aiocasambi_controller = None
         self._network_retry_timer = network_retry_timer
-        self.entities = []
+        self.entities = entities
 
     @property
     def aiocasambi_controller(self):

--- a/custom_components/casambi/casambi/CasambiController.py
+++ b/custom_components/casambi/casambi/CasambiController.py
@@ -29,6 +29,7 @@ class CasambiController:
         self._controller = None
         self._network_retry_timer = network_retry_timer
         self.units = units
+        self.entities = []
 
     @property
     def controller(self):
@@ -79,22 +80,23 @@ class CasambiController:
         Update unit state
         """
         _LOGGER.debug(f"update_unit_state: unit: {unit} units: {self.units}")
-        if unit in self.units:
-            self.units[unit].update_state()
+        for entity in self.entities:
+            if entity._unit_unique_id == unit:
+                entity.update_state()
 
     def update_all_units(self):
         """
         Update all the units state
         """
-        for key in self.units:
-            self.units[key].update_state()
+        for entity in self.entities:
+            entity.update_state()
 
     def set_all_units_offline(self):
         """
         Set all units to offline
         """
-        for key in self.units:
-            self.units[key].set_online(False)
+        for entity in self.entities:
+            entity.set_online(False)
 
     def signalling_callback(self, signal, data):
         """
@@ -104,15 +106,8 @@ class CasambiController:
         _LOGGER.debug(f"signalling_callback signal: {signal} data: {data}")
 
         if signal == SIGNAL_DATA:
-            for key, value in data.items():
-                unit = self.units.get(key)
-                if unit:
-                    self.units[key].process_update(value)
-                else:
-                    warn_msg = "signalling_callback: unit is None!"
-                    warn_msg += f"key: {key} signal: {signal} data: {data} "
-                    warn_msg += f"units: {pformat(self.units)}"
-                    _LOGGER.warning(warn_msg)
+            for entity in self.entities:
+                entity.process_update(data)
         elif signal == SIGNAL_CONNECTION_STATE and (data == STATE_STOPPED):
             _LOGGER.debug("signalling_callback websocket STATE_STOPPED")
 

--- a/custom_components/casambi/casambi/CasambiEntity.py
+++ b/custom_components/casambi/casambi/CasambiEntity.py
@@ -6,60 +6,51 @@ import logging
 from typing import Any, Dict
 
 from homeassistant.const import ATTR_NAME
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import DeviceInfo, Entity
 
-from ..const import (
-    DOMAIN,
-    ATTR_IDENTIFIERS,
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-)
+from ..const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-
 class CasambiEntity(Entity):
     """Defines a Casambi Entity."""
+    _attr_has_entity_name = True
 
-    def __init__(self, unit, controller, hass):
+    def __init__(self, unit, controller, hass, name: str = None):
         """Initialize Casambi Entity."""
+        _LOGGER.debug(f"Casambi entity - init - start")
         self.unit = unit
         self.controller = controller
         self.hass = hass
+        self._unit_unique_id = unit.unique_id
+        self._attr_name = name
 
-    @property
-    def name(self) -> str:
-        """Return the name of the entity."""
-        return self.unit.name
+        controller.entities.append(self)
+
+        _LOGGER.debug(f"Casambi entity - init - end")
 
     @property
     def unique_id(self) -> str:
         """Return the unique ID for this sensor."""
-        return self.unit.unique_id
+        name = self.unit.unique_id
+        if self._attr_name:
+            name += f"_{self._attr_name}"
+        return name.lower()
 
     @property
-    def model(self):
-        """Return the model for this sensor."""
-        if self.unit.fixture_model:
-            return self.unit.fixture_model
-        return "Casambi"
-
-    @property
-    def brand(self):
-        """Return the brand for this sensor."""
-        if self.unit.oem:
-            return self.unit.oem
-        return "Casambi"
-
-    @property
-    def device_info(self) -> Dict[str, Any]:
+    def device_info(self) -> DeviceInfo:
         """Return device information about this Casambi Key Light."""
-        return {
-            ATTR_IDENTIFIERS: {(DOMAIN, self.unique_id)},
-            ATTR_NAME: self.unit.name,
-            ATTR_MANUFACTURER: self.brand,
-            ATTR_MODEL: self.model,
-        }
+        _LOGGER.debug(f"DeviceInfo: unit: {self.unit}")
+        return DeviceInfo(
+            identifiers = {(DOMAIN, self.unit.unique_id)},
+            # default_name = "Casambi",
+            name = self.unit.name,
+            default_manufacturer = "Casambi",
+            manufacturer = self.unit.oem,
+            default_model = "Casambi",
+            model = self.unit.fixture_model,
+            sw_version = self.unit.firmware_version,
+        )
 
     @property
     def available(self) -> bool:
@@ -70,3 +61,7 @@ class CasambiEntity(Entity):
     def should_poll(self):
         """Disable polling by returning False"""
         return False
+
+    def __repr__(self) -> str:
+        """Return the representation."""
+        return f"<Casambi {self.unit.name}: unit={self.unit}"

--- a/custom_components/casambi/casambi/CasambiEntity.py
+++ b/custom_components/casambi/casambi/CasambiEntity.py
@@ -60,4 +60,4 @@ class CasambiEntity(Entity):
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"<Casambi {self.unit.name}: unit={self.unit}"
+        return f"<Casambi {self.unit.name}: unit={self.unit}>"

--- a/custom_components/casambi/casambi/CasambiLightEntity.py
+++ b/custom_components/casambi/casambi/CasambiLightEntity.py
@@ -38,7 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 class CasambiLightEntity(CoordinatorEntity, LightEntity, CasambiEntity):
     """Defines a Casambi Key Light."""
 
-    def __init__(self, coordinator, idx, unit, controller, hass):
+    def __init__(self, coordinator, unit, controller, hass):
         """Initialize Casambi Key Light."""
         CasambiEntity.__init__(self, unit, controller, hass)
         CoordinatorEntity.__init__(self, coordinator)

--- a/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
@@ -6,17 +6,15 @@ from .CasambiBinarySensorEntity import CasambiBinarySensorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-NAME = "Overheat"
-
 class CasambiOverheatBinarySensorEntity(CasambiBinarySensorEntity):
     def __init__(self, unit, controller, hass):
-        _LOGGER.debug(f"Casambi {NAME} binary sensor - init - start")
+        _LOGGER.debug(f"Casambi overheat binary sensor - init - start")
 
         CasambiBinarySensorEntity.__init__(self, unit, controller, hass,
-            NAME, BinarySensorDeviceClass.HEAT)
+            "Overheat", BinarySensorDeviceClass.HEAT)
 
-        _LOGGER.debug(f"Casambi {NAME} binary sensor - init - end")
+        _LOGGER.debug(f"Casambi overheat binary sensor - init - end")
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"<Casambi {NAME} binary sensor {self.unit.name}: unit={self.unit}"
+        return f"<Casambi overheat binary sensor {self.unit.name}: unit={self.unit}"

--- a/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
@@ -17,4 +17,4 @@ class CasambiOverheatBinarySensorEntity(CasambiBinarySensorEntity):
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"<Casambi overheat binary sensor {self.unit.name}: unit={self.unit}"
+        return f"<Casambi overheat binary sensor {self.unit.name}: unit={self.unit}>"

--- a/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
@@ -1,0 +1,26 @@
+
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+from .CasambiBinarySensorEntity import CasambiBinarySensorEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+_ENTITY_SUFFIX = "Overheat"
+
+class CasambiOverheatBinarySensorEntity(CasambiBinarySensorEntity):
+    def __init__(self, unit, controller, hass):
+        _LOGGER.debug(f"Casambi {name_suffix} binary sensor - init - start")
+
+        self._hass = hass
+        self._attr_icon = icon
+        self._attr_device_class = BinarySensorDeviceClass.HEAT
+        self._attr_is_on = False
+        CasambiBinarySensorEntity.__init__(self, unit, controller, hass, _ENTITY_SUFFIX)
+
+        _LOGGER.debug(f"Casambi {name_suffix} binary sensor - init - end")
+
+    def __repr__(self) -> str:
+        """Return the representation."""
+        return f"<Casambi {_ENTITY_SUFFIX} binary sensor {self.unit.name}: unit={self.unit}"

--- a/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -11,15 +10,15 @@ _ENTITY_SUFFIX = "Overheat"
 
 class CasambiOverheatBinarySensorEntity(CasambiBinarySensorEntity):
     def __init__(self, unit, controller, hass):
-        _LOGGER.debug(f"Casambi {name_suffix} binary sensor - init - start")
+        _LOGGER.debug(f"Casambi {_ENTITY_SUFFIX} binary sensor - init - start")
 
         self._hass = hass
-        self._attr_icon = icon
+        #self._attr_icon = icon
         self._attr_device_class = BinarySensorDeviceClass.HEAT
         self._attr_is_on = False
         CasambiBinarySensorEntity.__init__(self, unit, controller, hass, _ENTITY_SUFFIX)
 
-        _LOGGER.debug(f"Casambi {name_suffix} binary sensor - init - end")
+        _LOGGER.debug(f"Casambi {_ENTITY_SUFFIX} binary sensor - init - end")
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiOverheatBinarySensorEntity.py
@@ -6,20 +6,17 @@ from .CasambiBinarySensorEntity import CasambiBinarySensorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-_ENTITY_SUFFIX = "Overheat"
+NAME = "Overheat"
 
 class CasambiOverheatBinarySensorEntity(CasambiBinarySensorEntity):
     def __init__(self, unit, controller, hass):
-        _LOGGER.debug(f"Casambi {_ENTITY_SUFFIX} binary sensor - init - start")
+        _LOGGER.debug(f"Casambi {NAME} binary sensor - init - start")
 
-        self._hass = hass
-        #self._attr_icon = icon
-        self._attr_device_class = BinarySensorDeviceClass.HEAT
-        self._attr_is_on = False
-        CasambiBinarySensorEntity.__init__(self, unit, controller, hass, _ENTITY_SUFFIX)
+        CasambiBinarySensorEntity.__init__(self, unit, controller, hass,
+            NAME, BinarySensorDeviceClass.HEAT)
 
-        _LOGGER.debug(f"Casambi {_ENTITY_SUFFIX} binary sensor - init - end")
+        _LOGGER.debug(f"Casambi {NAME} binary sensor - init - end")
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"<Casambi {_ENTITY_SUFFIX} binary sensor {self.unit.name}: unit={self.unit}"
+        return f"<Casambi {NAME} binary sensor {self.unit.name}: unit={self.unit}"

--- a/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
@@ -1,6 +1,7 @@
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.entity import EntityCategory
 
 from .CasambiBinarySensorEntity import CasambiBinarySensorEntity
@@ -28,7 +29,7 @@ class CasambiStatusBinarySensorEntity(CasambiBinarySensorEntity):
 
     @property
     def state(self):
-        return "on" if self.unit.online else "off"
+        return STATE_ON if self.unit.online else STATE_OFF
 
     def update_state(self):
         """Update units state"""

--- a/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
@@ -1,0 +1,62 @@
+
+import logging
+
+from .CasambiBinarySensorEntity import CasambiBinarySensorEntity
+
+
+_LOGGER = logging.getLogger(__name__)
+
+_ENTITY_SUFFIX = "Status"
+
+class CasambiStatusBinarySensorEntity(CasambiBinarySensorEntity):
+    def __init__(self, unit, controller, hass):
+        CasambiBinarySensorEntity.__init__(
+            self, unit, controller, hass,
+            _ENTITY_SUFFIX,
+            # "mdi:google-lens",
+        )
+
+        # self._attr_icon = "mdi:light-flood-down"
+
+    def update_state(self):
+        """
+        Update units state
+        """
+        if self.enabled:
+            # Device needs to be enabled for us to schedule updates
+            _LOGGER.debug(f"update_state {self}")
+            self.async_schedule_update_ha_state(True)
+
+    # def process_update(self, data):
+    #     """Process callback message, update home assistant light state"""
+    #     _LOGGER.debug(f"process_update: self: {self} data: {data}")
+
+    #     if self.enabled:
+    #         # Device needs to be enabled for us to schedule updates
+    #         self.async_schedule_update_ha_state(True)
+
+    async def async_update(self) -> None:
+        """Update Casambi entity."""
+        _LOGGER.info(f"async_update: unit is not online: {self}")
+
+        if not self.unit.online:
+          self._attr_state = True
+        else:
+          self._attr_state = False
+
+        # else:
+            # if self.unit.value > 0:
+                # self._state = True
+                # self._brightness = int(round(self.unit.value * 255))
+                # self._distribution = int(round(self.unit.distribution * 255))
+            # else:
+            #     self._state = False
+        _LOGGER.debug(f"async_update {self}")
+
+    def __repr__(self) -> str:
+        """Return the representation."""
+        name = self.unit.name
+
+        result = f"<Casambi {_ENTITY_SUFFIX} binary sensor {name}: unit={self.unit}"
+
+        return result

--- a/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
@@ -24,7 +24,7 @@ class CasambiStatusBinarySensorEntity(CasambiBinarySensorEntity):
 
     @property
     def available(self) -> bool:
-        """Connectivity entity is always availble."""
+        """Connectivity entity is always available."""
         return True
 
     @property

--- a/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
@@ -1,8 +1,9 @@
-
 import logging
 
-from .CasambiBinarySensorEntity import CasambiBinarySensorEntity
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.helpers.entity import EntityCategory
 
+from .CasambiBinarySensorEntity import CasambiBinarySensorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -10,53 +11,20 @@ _ENTITY_SUFFIX = "Status"
 
 class CasambiStatusBinarySensorEntity(CasambiBinarySensorEntity):
     def __init__(self, unit, controller, hass):
-        CasambiBinarySensorEntity.__init__(
-            self, unit, controller, hass,
-            _ENTITY_SUFFIX,
-            # "mdi:google-lens",
-        )
+        _LOGGER.debug(f"Casambi {name_suffix} binary sensor - init - start")
 
-        # self._attr_icon = "mdi:light-flood-down"
+        self._hass = hass
+        self._attr_icon = icon
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._attr_is_on = False
+        CasambiBinarySensorEntity.__init__(self, unit, controller, hass, _ENTITY_SUFFIX)
 
-    def update_state(self):
-        """
-        Update units state
-        """
-        if self.enabled:
-            # Device needs to be enabled for us to schedule updates
-            _LOGGER.debug(f"update_state {self}")
-            self.async_schedule_update_ha_state(True)
+        _LOGGER.debug(f"Casambi {name_suffix} binary sensor - init - end")
 
-    # def process_update(self, data):
-    #     """Process callback message, update home assistant light state"""
-    #     _LOGGER.debug(f"process_update: self: {self} data: {data}")
-
-    #     if self.enabled:
-    #         # Device needs to be enabled for us to schedule updates
-    #         self.async_schedule_update_ha_state(True)
-
-    async def async_update(self) -> None:
-        """Update Casambi entity."""
-        _LOGGER.info(f"async_update: unit is not online: {self}")
-
-        if not self.unit.online:
-          self._attr_state = True
-        else:
-          self._attr_state = False
-
-        # else:
-            # if self.unit.value > 0:
-                # self._state = True
-                # self._brightness = int(round(self.unit.value * 255))
-                # self._distribution = int(round(self.unit.distribution * 255))
-            # else:
-            #     self._state = False
-        _LOGGER.debug(f"async_update {self}")
+    @property
+    def entity_category(self):
+        return EntityCategory.DIAGNOSTICS
 
     def __repr__(self) -> str:
         """Return the representation."""
-        name = self.unit.name
-
-        result = f"<Casambi {_ENTITY_SUFFIX} binary sensor {name}: unit={self.unit}"
-
-        return result
+        return f"<Casambi {_ENTITY_SUFFIX} binary sensor {self.unit.name}: unit={self.unit}"

--- a/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
@@ -15,30 +15,35 @@ class CasambiStatusBinarySensorEntity(CasambiBinarySensorEntity):
         CasambiBinarySensorEntity.__init__(self, unit, controller, hass,
             "Status", BinarySensorDeviceClass.CONNECTIVITY)
 
-        # self._attr_is_on = False
-        self._attr_state = self.unit.online
-
         _LOGGER.debug(f"Casambi status binary sensor - init - end")
 
     @property
     def entity_category(self):
         return EntityCategory.DIAGNOSTIC
 
-    # @property
-    # def state(self):
-    #     return self.controller.units[self._unit_unique_id].online
+    @property
+    def available(self) -> bool:
+        """Connectivity entity is always availble."""
+        return True
 
-    async def async_update(self) -> None:
-        """Update Casambi entity."""
-        self._attr_state = self.unit.online
-        _LOGGER.debug(f"async_update {self}")
+    @property
+    def state(self):
+        return "on" if self.unit.online else "off"
+
+    def update_state(self):
+        """Update units state"""
+        if self.enabled:
+            # Device needs to be enabled for us to schedule updates
+            _LOGGER.debug(f"update_state {self}")
+            self.async_schedule_update_ha_state(True)
 
     def process_update(self, data):
         """Process callback message, update home assistant light state"""
         _LOGGER.debug(f"process_update: self: {self} data: {data}")
         if self.enabled:
-            # Device needs to be enabled for us to schedule updates
-            self.async_schedule_update_ha_state(True)
+            if self._unit_unique_id in data:
+                # Device needs to be enabled for us to schedule updates
+                self.async_schedule_update_ha_state(True)
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
@@ -48,4 +48,4 @@ class CasambiStatusBinarySensorEntity(CasambiBinarySensorEntity):
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"<Casambi status binary sensor {self.unit.name}: unit={self.unit}"
+        return f"<Casambi status binary sensor {self.unit.name}: unit={self.unit}>"

--- a/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
@@ -11,15 +11,15 @@ _ENTITY_SUFFIX = "Status"
 
 class CasambiStatusBinarySensorEntity(CasambiBinarySensorEntity):
     def __init__(self, unit, controller, hass):
-        _LOGGER.debug(f"Casambi {name_suffix} binary sensor - init - start")
+        _LOGGER.debug(f"Casambi {_ENTITY_SUFFIX} binary sensor - init - start")
 
         self._hass = hass
-        self._attr_icon = icon
+        #self._attr_icon = icon
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
         self._attr_is_on = False
         CasambiBinarySensorEntity.__init__(self, unit, controller, hass, _ENTITY_SUFFIX)
 
-        _LOGGER.debug(f"Casambi {name_suffix} binary sensor - init - end")
+        _LOGGER.debug(f"Casambi {_ENTITY_SUFFIX} binary sensor - init - end")
 
     @property
     def entity_category(self):

--- a/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
+++ b/custom_components/casambi/casambi/CasambiStatusBinarySensorEntity.py
@@ -7,24 +7,39 @@ from .CasambiBinarySensorEntity import CasambiBinarySensorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-_ENTITY_SUFFIX = "Status"
 
 class CasambiStatusBinarySensorEntity(CasambiBinarySensorEntity):
     def __init__(self, unit, controller, hass):
-        _LOGGER.debug(f"Casambi {_ENTITY_SUFFIX} binary sensor - init - start")
+        _LOGGER.debug(f"Casambi status binary sensor - init - start")
 
-        self._hass = hass
-        #self._attr_icon = icon
-        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-        self._attr_is_on = False
-        CasambiBinarySensorEntity.__init__(self, unit, controller, hass, _ENTITY_SUFFIX)
+        CasambiBinarySensorEntity.__init__(self, unit, controller, hass,
+            "Status", BinarySensorDeviceClass.CONNECTIVITY)
 
-        _LOGGER.debug(f"Casambi {_ENTITY_SUFFIX} binary sensor - init - end")
+        # self._attr_is_on = False
+        self._attr_state = self.unit.online
+
+        _LOGGER.debug(f"Casambi status binary sensor - init - end")
 
     @property
     def entity_category(self):
-        return EntityCategory.DIAGNOSTICS
+        return EntityCategory.DIAGNOSTIC
+
+    # @property
+    # def state(self):
+    #     return self.controller.units[self._unit_unique_id].online
+
+    async def async_update(self) -> None:
+        """Update Casambi entity."""
+        self._attr_state = self.unit.online
+        _LOGGER.debug(f"async_update {self}")
+
+    def process_update(self, data):
+        """Process callback message, update home assistant light state"""
+        _LOGGER.debug(f"process_update: self: {self} data: {data}")
+        if self.enabled:
+            # Device needs to be enabled for us to schedule updates
+            self.async_schedule_update_ha_state(True)
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"<Casambi {_ENTITY_SUFFIX} binary sensor {self.unit.name}: unit={self.unit}"
+        return f"<Casambi status binary sensor {self.unit.name}: unit={self.unit}"

--- a/custom_components/casambi/const.py
+++ b/custom_components/casambi/const.py
@@ -15,6 +15,7 @@ CONF_USER_PASSWORD = "user_password"
 CONF_NETWORK_PASSWORD = "network_password"
 CONF_NETWORK_TIMEOUT = "network_timeout"
 CONF_CONTROLLER = "controller"
+CONF_COORDINATOR = "coordinator"
 
 SERVICE_CASAMBI_LIGHT_TURN_ON = "light_turn_on"
 ATTR_SERV_BRIGHTNESS = "brightness"

--- a/custom_components/casambi/light.py
+++ b/custom_components/casambi/light.py
@@ -183,7 +183,6 @@ async def async_setup_entry(
         )
         async_add_entities([casambi_light], True)
 
-        casambi_controller.units[casambi_light.unique_id] = casambi_light
 
     # add entity service to turn on Casambi light
     platform = entity_platform.async_get_current_platform()

--- a/custom_components/casambi/light.py
+++ b/custom_components/casambi/light.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
         if not unit.is_light():
             continue
 
-        casambi_light = CasambiLightEntity(coordinator, unit, controller.aiocasambi_controller, hass)
+        casambi_light = CasambiLightEntity(coordinator, unit, controller, hass)
         async_add_entities([casambi_light], True)
 
     # add entity service to turn on Casambi light
@@ -73,9 +73,9 @@ async def async_setup_entry(
 
 
 async def async_setup_platform(
-    hass: HomeAssistant, 
-    config_entry: ConfigEntry, 
-    async_add_entities, 
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities,
     discovery_info=None,
 ):
     """


### PR DESCRIPTION
**Work in Progress**

Adds a connectivity binary sensor as for ESPhome devices. Related to [#54](https://github.com/hellqvio86/home_assistant_casambi/issues/54#issuecomment-1321535411). Requires #74.

<img width="338" alt="Bildschirm­foto 2022-11-23 um 22 32 29" src="https://user-images.githubusercontent.com/9592452/203649578-bd80c311-7076-49fa-8cc7-375f91042e7e.png">
