### PR TITLE
feat: use new way of entity naming

### DIFF
--- a/custom_components/casambi/casambi/CasambiEntity.py
+++ b/custom_components/casambi/casambi/CasambiEntity.py
@@ -15,17 +15,14 @@ _LOGGER = logging.getLogger(__name__)
 
 class CasambiEntity(Entity):
     """Defines a Casambi Entity."""
+    _attr_has_entity_name = True
 
-    def __init__(self, unit, controller, hass):
+    def __init__(self, unit, controller, hass, name: str = None):
         """Initialize Casambi Entity."""
         self.unit = unit
         self.controller = controller
         self.hass = hass
-
-    @property
-    def name(self) -> str:
-        """Return the name of the entity."""
-        return self.unit.name
+        self._attr_name = name
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
With this PR the *light* entity inherits it's name from the device and therefore following the [*new way of entity naming*](https://developers.home-assistant.io/blog/2022/07/10/entity_naming/).

See also https://developers.home-assistant.io/docs/core/entity/#entity-naming