### PR TITLE
feat: add IoT Class to integration manifest

### DIFF
--- a/custom_components/casambi/manifest.json
+++ b/custom_components/casambi/manifest.json
@@ -14,5 +14,6 @@
   "dependencies": [],
   "codeowners": [
     "@hellqvio86"
-  ]
+  ],
+  "iot_class": "cloud_polling"
 }

--- a/custom_components/casambi/manifest.json
+++ b/custom_components/casambi/manifest.json
@@ -15,5 +15,5 @@
   "codeowners": [
     "@hellqvio86"
   ],
-  "iot_class": "cloud_polling"
+  "iot_class": "cloud_push"
 }


### PR DESCRIPTION
Adds the [IoT Class](https://developers.home-assistant.io/docs/creating_integration_manifest/#iot-class) the the integration manifest.

<img width="292" alt="Bildschirm­foto 2023-01-02 um 10 24 58" src="https://user-images.githubusercontent.com/9592452/210213431-8e4e1cec-8936-4ce5-a7dd-c15f3916ab58.png">

<img width="291" alt="Bildschirm­foto 2023-01-02 um 11 47 17" src="https://user-images.githubusercontent.com/9592452/210221443-9a9f6ecf-f172-49e6-9946-ad9da4ee16e2.png">

